### PR TITLE
Provide curl to derived containers.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get -q update
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get -q -y dist-upgrade
 RUN DEBIAN_FRONTEND=noninteractive \
-    apt-get -q -y install software-properties-common
+    apt-get -q -y install curl software-properties-common
 
 ENTRYPOINT ["/bin/bash"]
 CMD []


### PR DESCRIPTION
Fixes #1 

A lot of the containers that we will build from this container will use
curl to install software. So we provide curl here to speed-up building
derived containers.

The target branch is 15.10 which is unusual. Normally this would be master but we do this because of how automated builds work on hub.docker.com (which we don't use currently use but plan to soon).
