### PR TITLE
Provide make to derived containers.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get -q update                   \
     && DEBIAN_FRONTEND=noninteractive   \
     apt-get -q -y install               \
         curl                            \
+        make                            \
         software-properties-common=*    \
     && apt-get -q clean                 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes #8 . Depends on #7 to be merged first.

This is the same as #3 but with make instead of curl.
