### PR TITLE
Use Ubuntu 16.04 as "latest."

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:15.10
+FROM ubuntu:16.04
 MAINTAINER "Tom Vaughan <tvaughan@lynxtp.com>"
 
 RUN apt-get -q update                   \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CONTAINER = lynxtp/ubuntu
-VERSION = 15.10
+VERSION = 16.04
 
 DOCKER ?= docker
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 Create a script called `bash` that looks like:
 
     #!/bin/sh
-    docker run --rm -i -t lynxtp/ubuntu:15.10 bash "$@"
+    docker run --rm -i -t lynxtp/ubuntu:16.04 bash "$@"
 
 make it executable, and then run it.

--- a/bash
+++ b/bash
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 # -*- coding: utf-8; mode: sh -*-
 CONTAINER=lynxtp/ubuntu
-VERSION=15.10
+VERSION=16.04
 CMD=$(basename $0)
 docker run --rm -i -t -v $PWD:/mnt/workdir -w /mnt/workdir $CONTAINER:$VERSION $CMD "$@"
 exit 0


### PR DESCRIPTION
Fixes #15 . We already use this version as we specify 16.04 explicitly. This just makes 16.04 the default version and removes any possibility that we could use 15.10 by mistake.
